### PR TITLE
Change the archive.today link

### DIFF
--- a/crestify/archivers/archivetoday.py
+++ b/crestify/archivers/archivetoday.py
@@ -12,7 +12,7 @@ class ArchiveTodayService(ArchiveService):
             "--ignore-ssl-errors=true",
             "--ssl-protocol=tlsv1",
             "--load-images=no"])
-        browser.get('https://archive.is')
+        browser.get('https://archive.li')
         input = browser.find_element_by_id('url')
         input.send_keys(url)
         input.submit()


### PR DESCRIPTION
https://archive.is is not available anymore. https://archive.li is working.